### PR TITLE
feat: Implement `Comparable` for `PlanckDuration` and fix precision l…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-01-17
+
+### Added
+- `Comparable` interface implementation for `PlanckDuration` class, enabling easy sorting.
+
+### Fixed
+- Precision loss when creating `PlanckDuration` from fractional double values (e.g., `1.5.nanoseconds`). Calculations now use full double precision instead of rounding to the nearest integer.
+
 ## [2.0.1] - 2025-11-30
 
 ### Fixed

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,0 +1,37 @@
+import 'package:simple_durations/simple_durations.dart';
+
+void main() {
+  print('--- Simple Durations Example ---');
+
+  // Basic Duration creation
+  final duration = 5.minutes;
+  print('5.minutes: $duration');
+
+  // Fractional Duration
+  final halfMinute = 0.5.minutes;
+  print('0.5.minutes: $halfMinute');
+
+  // PlanckDuration with high precision
+  final preciseNano = 1.5.nanoseconds;
+  print('1.5.nanoseconds: $preciseNano');
+
+  // Verify precision (should be 1500 picoseconds, not 2000 if rounded)
+  print('in Picoseconds: ${preciseNano.inPicoseconds.toStringAsFixed(1)}');
+
+  // Arithmetic
+  final sum = 1.nanoseconds + 0.5.nanoseconds;
+  print('1.ns + 0.5.ns = $sum');
+
+  // Comparisons
+  final small = 1.nanoseconds;
+  final large = 2.nanoseconds;
+  print('1.ns < 2.ns: ${small < large}');
+
+  // Sorting (Comparable)
+  final list = [large, small, preciseNano];
+  print('Original list: $list');
+  list.sort();
+  print('Sorted list:   $list');
+
+  print('--------------------------------');
+}

--- a/lib/src/planck_duration.dart
+++ b/lib/src/planck_duration.dart
@@ -58,7 +58,7 @@ import 'package:simple_durations/simple_durations.dart';
 /// - Conversion to [Duration] may lose precision for very small values
 /// - All arithmetic operations preserve precision within floating-point limits
 @immutable
-class PlanckDuration {
+class PlanckDuration implements Comparable<PlanckDuration> {
   /// Creates a new [PlanckDuration] object.
   ///
   /// The duration can be specified in any of the following units:
@@ -83,24 +83,24 @@ class PlanckDuration {
   /// * [quectoseconds]
   /// * [plancks]
   PlanckDuration({
-    int days = 0,
-    int hours = 0,
-    int minutes = 0,
-    int seconds = 0,
-    int milliseconds = 0,
-    int microseconds = 0,
-    int shakes = 0,
-    int nanoseconds = 0,
-    int picoseconds = 0,
-    int svedbergs = 0,
-    int femtoseconds = 0,
-    int atomics = 0,
-    int attoseconds = 0,
-    int zeptoseconds = 0,
-    int physicsJiffys = 0,
-    int yoctoseconds = 0,
-    int rontoseconds = 0,
-    int quectoseconds = 0,
+    num days = 0,
+    num hours = 0,
+    num minutes = 0,
+    num seconds = 0,
+    num milliseconds = 0,
+    num microseconds = 0,
+    num shakes = 0,
+    num nanoseconds = 0,
+    num picoseconds = 0,
+    num svedbergs = 0,
+    num femtoseconds = 0,
+    num atomics = 0,
+    num attoseconds = 0,
+    num zeptoseconds = 0,
+    num physicsJiffys = 0,
+    num yoctoseconds = 0,
+    num rontoseconds = 0,
+    num quectoseconds = 0,
     double plancks = 0,
   }) : _plancks = _validateAndCalculate(
          days,
@@ -126,24 +126,24 @@ class PlanckDuration {
 
   /// Validates input parameters and calculates total planck times.
   static double _validateAndCalculate(
-    int days,
-    int hours,
-    int minutes,
-    int seconds,
-    int milliseconds,
-    int microseconds,
-    int shakes,
-    int nanoseconds,
-    int picoseconds,
-    int svedbergs,
-    int femtoseconds,
-    int atomics,
-    int attoseconds,
-    int zeptoseconds,
-    int physicsJiffys,
-    int yoctoseconds,
-    int rontoseconds,
-    int quectoseconds,
+    num days,
+    num hours,
+    num minutes,
+    num seconds,
+    num milliseconds,
+    num microseconds,
+    num shakes,
+    num nanoseconds,
+    num picoseconds,
+    num svedbergs,
+    num femtoseconds,
+    num atomics,
+    num attoseconds,
+    num zeptoseconds,
+    num physicsJiffys,
+    num yoctoseconds,
+    num rontoseconds,
+    num quectoseconds,
     double plancks,
   ) {
     // Validate that all parameters are non-negative

--- a/lib/src/simple_durations.dart
+++ b/lib/src/simple_durations.dart
@@ -383,40 +383,40 @@ extension SimpleDurationsDouble on double {
   PlanckDuration get plancks => PlanckDuration(plancks: this);
 
   /// Returns a [PlanckDuration] of this many quectoseconds.
-  PlanckDuration get quectoseconds => PlanckDuration(quectoseconds: round());
+  PlanckDuration get quectoseconds => PlanckDuration(quectoseconds: this);
 
   /// Returns a [PlanckDuration] of this many rontoseconds.
-  PlanckDuration get rontoseconds => PlanckDuration(rontoseconds: round());
+  PlanckDuration get rontoseconds => PlanckDuration(rontoseconds: this);
 
   /// Returns a [PlanckDuration] of this many yoctoseconds.
-  PlanckDuration get yoctoseconds => PlanckDuration(yoctoseconds: round());
+  PlanckDuration get yoctoseconds => PlanckDuration(yoctoseconds: this);
 
   /// Returns a [PlanckDuration] of this many physics jiffys.
-  PlanckDuration get jiffyPhysics => PlanckDuration(physicsJiffys: round());
+  PlanckDuration get jiffyPhysics => PlanckDuration(physicsJiffys: this);
 
   /// Returns a [PlanckDuration] of this many zeptoseconds.
-  PlanckDuration get zeptosecond => PlanckDuration(zeptoseconds: round());
+  PlanckDuration get zeptosecond => PlanckDuration(zeptoseconds: this);
 
   /// Returns a [PlanckDuration] of this many attoseconds.
-  PlanckDuration get attoseconds => PlanckDuration(attoseconds: round());
+  PlanckDuration get attoseconds => PlanckDuration(attoseconds: this);
 
   /// Returns a [PlanckDuration] of this many atomic units of time.
-  PlanckDuration get atomics => PlanckDuration(atomics: round());
+  PlanckDuration get atomics => PlanckDuration(atomics: this);
 
   /// Returns a [PlanckDuration] of this many femtoseconds.
-  PlanckDuration get femtoseconds => PlanckDuration(femtoseconds: round());
+  PlanckDuration get femtoseconds => PlanckDuration(femtoseconds: this);
 
   /// Returns a [PlanckDuration] of this many svedbergs.
-  PlanckDuration get svedbergs => PlanckDuration(svedbergs: round());
+  PlanckDuration get svedbergs => PlanckDuration(svedbergs: this);
 
   /// Returns a [PlanckDuration] of this many picoseconds.
-  PlanckDuration get picoseconds => PlanckDuration(picoseconds: round());
+  PlanckDuration get picoseconds => PlanckDuration(picoseconds: this);
 
   /// Returns a [PlanckDuration] of this many nanoseconds.
-  PlanckDuration get nanoseconds => PlanckDuration(nanoseconds: round());
+  PlanckDuration get nanoseconds => PlanckDuration(nanoseconds: this);
 
   /// Returns a [PlanckDuration] of this many shakes.
-  PlanckDuration get shakes => PlanckDuration(shakes: round());
+  PlanckDuration get shakes => PlanckDuration(shakes: this);
 
   /// Returns a [Duration] of this many centiseconds.
   Duration get centiseconds =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: simple_durations
 description: "Extensions on int to easily create Durations directly from ints. Can be used for units as small as planck time all the way up to galactic years and beyond."
-version: 2.0.1
+version: 2.1.0
 repository: https://github.com/johnbmangold/simple_durations
 issue_tracker: https://github.com/johnbmangold/simple_durations/issues
 

--- a/test/planck_duration_test.dart
+++ b/test/planck_duration_test.dart
@@ -202,6 +202,17 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
     });
+    test('Comparable interface implemented', () {
+      final list = [
+        PlanckDuration(seconds: 10),
+        PlanckDuration(seconds: 1),
+        PlanckDuration(seconds: 5),
+      ];
+      list.sort();
+      expect(list[0].inSeconds, equals(1));
+      expect(list[1].inSeconds, equals(5));
+      expect(list[2].inSeconds, equals(10));
+    });
   });
 
   group('SimpleDurationsDouble', () {
@@ -209,10 +220,8 @@ void main() {
       expect(2.5.seconds.inMicroseconds, equals(2500000));
       expect(1.5.milliseconds.inMicroseconds, equals(1500));
       expect(0.5.minutes.inSeconds, equals(30));
-      // Note: double extensions round to integers, so 1.5 becomes 2
-      expect(1.5.nanoseconds.inPicoseconds, closeTo(2000.0, 1e-6));
-      // Note: double extensions round to integers, so 2.5 becomes 3
-      expect(2.5.picoseconds.inFemtoseconds, closeTo(3000.0, 1e-10));
+      expect(1.5.nanoseconds.inPicoseconds, closeTo(1500.0, 1e-6));
+      expect(2.5.picoseconds.inFemtoseconds, closeTo(2500.0, 1e-10));
     });
 
     test('double extensions handle fractional values', () {


### PR DESCRIPTION
…oss when creating from fractional `double` values.