### PR TITLE
🧪 [testing improvement] Add test for physicsJiffys validation

### DIFF
--- a/test/planck_duration_test.dart
+++ b/test/planck_duration_test.dart
@@ -201,6 +201,10 @@ void main() {
         () => PlanckDuration(plancks: -1),
         throwsA(isA<ArgumentError>()),
       );
+      expect(
+        () => PlanckDuration(physicsJiffys: -1),
+        throwsA(isA<ArgumentError>()),
+      );
     });
     test('Comparable interface implemented', () {
       final list = [


### PR DESCRIPTION
🎯 **What:** Added a missing test case for validating negative input for `physicsJiffys` in the `PlanckDuration` constructor.
📊 **Coverage:** The test suite now explicitly covers the negative input validation logic for `physicsJiffys`, alongside `seconds`, `milliseconds`, and `plancks`.
✨ **Result:** Improved test coverage and reliability for edge cases involving negative durations for specialized time units.

---
*PR created automatically by Jules for task [1691454665874867668](https://jules.google.com/task/1691454665874867668) started by @johnbmangold*