### PR TITLE
🧹 Remove unused SHAKE constant

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -60,9 +60,6 @@ const PICOSECOND = 1e-12;
 /// Nanosecond (10^-9 seconds).
 const NANOSECOND = 1e-9;
 
-/// Shake (10^-8 seconds).
-const SHAKE = 1e-8;
-
 /// Centisecond (0.01 seconds).
 const CENTISECOND = 1e-2;
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `SHAKE` constant from `lib/src/constants.dart`.
💡 **Why:** This improves maintainability and readability by eliminating dead code that is not referenced anywhere in the codebase.
✅ **Verification:** Verified through `grep` that `SHAKE` (as a whole word) was not used in any other file. Confirmed that the related `PLANCKS_IN_SHAKE` constant is still present and correctly used in `lib/src/planck_duration.dart`.
✨ **Result:** A cleaner and more maintainable codebase by removing unnecessary constants.

---
*PR created automatically by Jules for task [14373786871830736468](https://jules.google.com/task/14373786871830736468) started by @johnbmangold*