### PR TITLE
🧪 [testing improvement] Test negative microseconds throws ArgumentError

### DIFF
--- a/test/planck_duration_test.dart
+++ b/test/planck_duration_test.dart
@@ -201,6 +201,10 @@ void main() {
         () => PlanckDuration(plancks: -1),
         throwsA(isA<ArgumentError>()),
       );
+      expect(
+        () => PlanckDuration(microseconds: -1),
+        throwsA(isA<ArgumentError>()),
+      );
     });
     test('Comparable interface implemented', () {
       final list = [


### PR DESCRIPTION
- 🎯 **What:** Added a test case to verify that the `PlanckDuration` constructor throws an `ArgumentError` when provided with negative microseconds.
- 📊 **Coverage:** Expanded the `constructor validates negative values` test group in `test/planck_duration_test.dart`.
- ✨ **Result:** Increased the reliability of the codebase by ensuring that invalid negative input for microseconds is explicitly tested and handled.

---
*PR created automatically by Jules for task [14486576472396474199](https://jules.google.com/task/14486576472396474199) started by @johnbmangold*